### PR TITLE
Updated pwr.p.test

### DIFF
--- a/R/pwr.2p.test.R
+++ b/R/pwr.2p.test.R
@@ -50,7 +50,7 @@ function (h = NULL, n = NULL, sig.level = 0.05, power = NULL,
 }
     else if (is.null(n)) 
         n <- uniroot(function(n) eval(p.body) - power, c(2 + 
-            1e-10, 1e+05))$root
+            1e-10, 1e+09))$root
     else if (is.null(sig.level)) 
         sig.level <- uniroot(function(sig.level) eval(p.body) - 
             power, c(1e-10, 1 - 1e-10))$root

--- a/R/pwr.anova.test.R
+++ b/R/pwr.anova.test.R
@@ -28,7 +28,7 @@ function (k = NULL, n = NULL, f = NULL, sig.level = 0.05, power = NULL)
             1e-10, 100))$root
     else if (is.null(n)) 
         n <- uniroot(function(n) eval(p.body) - power, c(2 + 
-            1e-10, 1e+05))$root
+            1e-10, 1e+00))$root
     else if (is.null(f)) 
         f <- uniroot(function(f) eval(p.body) - power, c(1e-07, 
             1e+07))$root

--- a/R/pwr.p.test.R
+++ b/R/pwr.p.test.R
@@ -50,7 +50,7 @@ if (tside == 1) {
 }
     else if (is.null(n)) 
         n <- uniroot(function(n) eval(p.body) - power, c(2 + 
-            1e-10, 1e+05))$root
+            1e-10, 1e+09))$root
     else if (is.null(sig.level)) 
         sig.level <- uniroot(function(sig.level) eval(p.body) - 
             power, c(1e-10, 1 - 1e-10))$root

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-[![Build Status](https://travis-ci.org/heliosdrm/pwr.svg?branch=master)](https://travis-ci.org/heliosdrm/pwr)
-
 # R package &ldquo;pwr&rdquo;
 ## Basic functions for power analysis
+
+[![Build Status](https://travis-ci.org/heliosdrm/pwr.svg?branch=master)](https://travis-ci.org/heliosdrm/pwr)
+
+[![CRAN version](http://www.r-pkg.org/badges/version/pwr)](http://www.r-pkg.org/pkg/pwr)
+[![Downloads](http://cranlogs.r-pkg.org/badges/pwr)]()
 
 This package was originally created by Stephane Champely, from the University of Lyon.
 


### PR DESCRIPTION
Changed the upper limit of n from 5 to 9 digits, for the function to be able to work in situations where n is greater than or equal to 100,000 (lines 52-53). I verified that the program didn't take any longer than it did when the upper limit was 5 digits. For internet-scale testing, it's frequently the case that the effect size is very small, and the number of observations required is larger than 100,000.  For example, for p0=5% and p1=5.15%, the number of observations required is 132367.  Small effects like this over large populations are especially common in e-commerce, search, and advertising.  The legacy function returns an error in such situations because the search space for n is limited to 100,000.  This change increases the search interval for sample size to 10 million, to account for these sorts of scenarios.
