### PR TITLE
Update plot.power.htest.R

### DIFF
--- a/R/plot.power.htest.R
+++ b/R/plot.power.htest.R
@@ -13,6 +13,9 @@ plot.power.htest <- function (x, ...){
   # case: One-sample, Two-sample or Paired t test
   if(x$method == "One-sample t test power calculation" || x$method == "Two-sample t test power calculation" || x$method == "Paired t test power calculation")
   {
+    if(x$method == "One-sample t test power calculation"){x$type = "one.sample"}
+    if(x$method == "Two-sample t test power calculation"){x$type = "two.sample"}
+    if(x$method == "Paired t test power calculation"){x$type = "paired"}
     n <- x$n
     n_upper <- max(n*1.5, n+30) # upper at least 30 above n
     


### PR DESCRIPTION
When the pwr.t.test function is called from plot.power.htest it attempts to specify the type parameter by setting it to x$type. However, the x object doesn’t contain any type, and therefore the pwr.t.test function defaults always to type = “two.sample”.

With this patch the power is now correctly calculated as a function of the test type (two.sample, one.sample, paired).